### PR TITLE
iamroot17A: 14주차 스터디

### DIFF
--- a/arch/arm64/include/asm/cputype.h
+++ b/arch/arm64/include/asm/cputype.h
@@ -190,11 +190,21 @@ is_midr_in_range_list(u32 midr, struct midr_range const *ranges)
  */
 static inline u32 __attribute_const__ read_cpuid_id(void)
 {
+	/*; Iamroot17A 2020.Nov.28 #5.1
+	 *;
+	 *; Main ID Register, 제조사 정보 등이 포함된 SYSREG
+	 *; >> https://developer.arm.com/docs/ddi0595/h/aarch64-system-registers/midr_el1
+	 *; */
 	return read_cpuid(MIDR_EL1);
 }
 
 static inline u64 __attribute_const__ read_cpuid_mpidr(void)
 {
+	/*; Iamroot17A 2020.Nov.28 #5.2
+	 *;
+	 *; MultiProcessor Affinity register, CPU 자체 정보에 대한 SYSREG
+	 *; >> https://developer.arm.com/docs/ddi0595/d/aarch64-system-registers/mpidr_el1
+	 *; */
 	return read_cpuid(MPIDR_EL1);
 }
 

--- a/arch/arm64/kernel/setup.c
+++ b/arch/arm64/kernel/setup.c
@@ -84,6 +84,10 @@ u64 __cacheline_aligned boot_args[4];
 
 void __init smp_setup_processor_id(void)
 {
+	/*; Iamroot17A 2020.Nov.28 #4
+	 *;
+	 *; 현재 CPU ID를 가져온다. (MultiProcessor ID Register)
+	 *; */
 	u64 mpidr = read_cpuid_mpidr() & MPIDR_HWID_BITMASK;
 	set_cpu_logical_map(0, mpidr);
 
@@ -93,6 +97,12 @@ void __init smp_setup_processor_id(void)
 	 * access percpu variable inside lock_release
 	 */
 	set_my_cpu_offset(0);
+	/*; Iamroot17A 2020.Nov.28 #5
+	 *;
+	 *; 위에서는 read_cpuid_mpidr()을 사용하고, 아래 printk에서는
+	 *; 추가적으로 read_cpuid_id()를 사용하고 있다.
+	 *; 이름은 비슷해보이지만 서로 다른 레지스터의 값을 가져오고 있음.
+	 *; */
 	pr_info("Booting Linux on physical CPU 0x%010lx [0x%08x]\n",
 		(unsigned long)mpidr, read_cpuid_id());
 }

--- a/include/asm-generic/atomic-instrumented.h
+++ b/include/asm-generic/atomic-instrumented.h
@@ -39,9 +39,22 @@ atomic_read_acquire(const atomic_t *v)
 #define atomic_read_acquire atomic_read_acquire
 #endif
 
+/*; Iamroot17A 2020.Nov.28 #10.3
+ *;
+ *; Architecture dependent하게 구현된 atomic_set
+ *; 아래 arch_atomic_set은 각 arch/$ARCH/include/asm/atomic.h에 정의된
+ *; atomic_set을 호출하게 된다. (대부분 결과적으로 WRITE_ONCE를 사용한다.)
+ *; Atomic load/store를 위한 instruction이 지원되는데 왜 WRITE_ONCE를
+ *; 사용하는지는 확인해봐야 할 것 같음.
+ *; */
 static __always_inline void
 atomic_set(atomic_t *v, int i)
 {
+	/*; Iamroot17A 2020.Nov.28 #10.4
+	 *;
+	 *; Kernel Sanitizer 사용시 검증하는 코드가 수행됨.
+	 *; (Kernel Address Sanitizer, Kernel Concurrency Sanitizer)
+	 *; */
 	instrument_atomic_write(v, sizeof(*v));
 	arch_atomic_set(v, i);
 }

--- a/include/asm-generic/atomic-instrumented.h
+++ b/include/asm-generic/atomic-instrumented.h
@@ -45,6 +45,12 @@ atomic_set(atomic_t *v, int i)
 	instrument_atomic_write(v, sizeof(*v));
 	arch_atomic_set(v, i);
 }
+/*; Iamroot17A 2020.Nov.28 #10.2
+ *;
+ *; macro define을 위에서 선언한 inline 함수로 하고 있음. 예상되는 이유는 같은
+ *; 이름의 macro를 쓰는 header를 동시 include했을 때 생길 문제를 방지하기 위해
+ *; preprocessor 단계에서 미리 inline 함수 호출로 치환하는 것으로 보임.
+ *; */
 #define atomic_set atomic_set
 
 #if defined(arch_atomic_set_release)

--- a/include/asm-generic/atomic.h
+++ b/include/asm-generic/atomic.h
@@ -176,6 +176,10 @@ ATOMIC_OP(xor, ^)
  *
  * Atomically sets the value of @v to @i.
  */
+/*; Iamroot17A 2020.Nov.28 #10.1
+ *;
+ *; Architecture independent하게 구현된 atomic_set, WRITE_ONCE를 사용한다.
+ *; */
 #define atomic_set(v, i) WRITE_ONCE(((v)->counter), (i))
 
 #include <linux/irqflags.h>

--- a/include/linux/compiler_attributes.h
+++ b/include/linux/compiler_attributes.h
@@ -49,6 +49,13 @@
  *   gcc: https://gcc.gnu.org/onlinedocs/gcc/Common-Type-Attributes.html#index-aligned-type-attribute
  *   gcc: https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html#index-aligned-variable-attribute
  */
+/*; Iamroot17A 2020.Nov.28 #1.4
+ *;
+ *; 기존 .align과 다르게 __aligned(x) macro의 X는 2의 제곱수로 넣어야 한다.
+ *; (/include/linux/linkage.h에 선언된 .align)
+ *; (.align은 assembler에서 적용, __aligned는 compiler에서 적용)
+ *; >> Iamroot17A 2020.Oct.24 #14 참고
+ *; */
 #define __aligned(x)                    __attribute__((__aligned__(x)))
 #define __aligned_largest               __attribute__((__aligned__))
 

--- a/include/linux/list.h
+++ b/include/linux/list.h
@@ -32,6 +32,11 @@
  */
 static inline void INIT_LIST_HEAD(struct list_head *list)
 {
+	/*; Iamroot17A 2020.Nov.28 #9.1
+	 *;
+	 *; list->next의 값을 바꾸는 부분만 WRITE_ONCE 처리되어있다.
+	 *; >> 관련 commit: 2f073848c3cc8aff2655ab7c46d8c0de90cf4e50
+	 *; */
 	WRITE_ONCE(list->next, list);
 	list->prev = list;
 }

--- a/include/linux/list.h
+++ b/include/linux/list.h
@@ -36,6 +36,19 @@ static inline void INIT_LIST_HEAD(struct list_head *list)
 	 *;
 	 *; list->next의 값을 바꾸는 부분만 WRITE_ONCE 처리되어있다.
 	 *; >> 관련 commit: 2f073848c3cc8aff2655ab7c46d8c0de90cf4e50
+	 *;
+	 *; 왜 list->next만 WRITE_ONCE처리 했는가?
+	 *; WRITE_ONCE는 해당 변수에 write하는 작업을 atomic하게 하려고 사용하는
+	 *; macro이다. 내부적으로 volatile을 사용하는데 이것이 compiler 단에서
+	 *; Memory barrier와 유사한 역할을 수행할 것으로 예상됨.
+	 *; >> https://stackoverflow.com/questions/34988277 참고
+	 *; >> https://gcc.gnu.org/onlinedocs/gcc/Volatiles.html 참고
+	 *;
+	 *; 해당 가설에 가능성을 보충하자면, inline 함수의 경우 function call에
+	 *; 의한 overhead(Stack frame push/pop, branch 등)를 줄여주는 것은
+	 *; 당연하며, 추가적으로 함수 호출과 관련된 인자 사이의 최적화도 진행됨.
+	 *; (ex. Parameter validation을 dead code 취급해서 삭제하는 식)
+	 *; >> https://en.wikipedia.org/wiki/Inline_expansion#Benefits 참고
 	 *; */
 	WRITE_ONCE(list->next, list);
 	list->prev = list;

--- a/include/linux/lockdep_types.h
+++ b/include/linux/lockdep_types.h
@@ -61,6 +61,14 @@ struct lockdep_subclass_key {
 } __attribute__ ((__packed__));
 
 /* hash_entry is used to keep track of dynamically allocated keys. */
+/*; Iamroot17A 2020.Nov.28 #12.1
+ *;
+ *; lockdep: lock의 유효성 검증을 위한 기능의 헤더
+ *; 현재 mutex, spin_lock 초기화 시 사용되는 구조체 (debug_XXX의 Arg로 사용되며
+ *;  debug시 lock의 정보를 알아내기 위해 사용되는 것으로 보임.)
+ *; lock이 걸린 상태에서 또 lock을 시도하는지 확인하는 것과 관련된 것으로 예상
+ *; >> 관련 commit: de8f5e4f2dc1f032b46afda0a78cab5456974f89
+ *; */
 struct lock_class_key {
 	union {
 		struct hlist_node		hash_entry;

--- a/include/linux/mutex.h
+++ b/include/linux/mutex.h
@@ -54,6 +54,15 @@ struct mutex {
 	atomic_long_t		owner;
 	spinlock_t		wait_lock;
 #ifdef CONFIG_MUTEX_SPIN_ON_OWNER
+	/*; Iamroot17A 2020.Nov.28 #12.2
+	 *;
+	 *; 리눅스 커널 내에는 lock이 걸려 있을 때, spin_lock 기법을 사용한다.
+	 *; (unlock을 기다리느라 코드를 수행하지 못한다면 해당 task를 sched하지
+	 *;  않고, 금방 unlock될 것이라 기대하며 계속 busy-waiting하는 것)
+	 *; optimistic_spin_queue는 이 spin_lock으로 바로 코드를 수행할 수
+	 *; 있을 것이라 기대하면서 기다리는 queue를 뜻하는 것으로 보임.
+	 *; >> http://jake.dothome.co.kr/mutex/ 참고
+	 *; */
 	struct optimistic_spin_queue osq; /* Spinner MCS lock */
 #endif
 	struct list_head	wait_list;

--- a/include/linux/rcupdate.h
+++ b/include/linux/rcupdate.h
@@ -334,6 +334,13 @@ static inline void rcu_preempt_sleep_check(void) { }
  */
 
 #ifdef __CHECKER__
+/*; Iamroot17A 2020.Nov.28 #16.1
+ *;
+ *; rcu_check_sparse는 실제 코드상의 기능보다는 정적 분석 과정에서 오류를
+ *; 확인하는 것으로 보임. (type과 space를 기준으로 reference 가능 여부에 대한
+ *; 조건을 확인할 뿐, 해당 논리 식의 결과를 void로 casting하여 비교 결과를
+ *; 버리는 것을 확인할 수 있다.)
+ *; */
 #define rcu_check_sparse(p, space) \
 	((void)(((typeof(*p) space *)p) == p))
 #else /* #ifdef __CHECKER__ */

--- a/include/linux/sched.h
+++ b/include/linux/sched.h
@@ -634,6 +634,11 @@ struct task_struct {
 	 * For reasons of header soup (see current_thread_info()), this
 	 * must be the first element of task_struct.
 	 */
+	/*; Iamroot17A 2020.Nov.28 #1.1
+	 *;
+	 *; task_struct 안에는 thread_info를 포함하고 있으며 (defconfig에서 y)
+	 *; 해당 구조체는 architecture 종속적이다.
+	 *; */
 	struct thread_info		thread_info;
 #endif
 	/* -1 unrunnable, 0 runnable, >0 stopped: */
@@ -643,6 +648,12 @@ struct task_struct {
 	 * This begins the randomizable portion of task_struct. Only
 	 * scheduling-critical items should be added above here.
 	 */
+	/*; Iamroot17A 2020.Nov.28 #1.2
+	 *;
+	 *; 아래 항목들은 필드 순서가 무작위로 배치된다.
+	 *; (randomized_struct_fields_start ~ randomized_struct_fields_end)
+	 *; (아래 영역을 struct로 묶고 __attribute__((randomize_layout)) 적용)
+	 *; */
 	randomized_struct_fields_start
 
 	void				*stack;

--- a/include/linux/sched/task_stack.h
+++ b/include/linux/sched/task_stack.h
@@ -23,6 +23,12 @@ static inline void *task_stack_page(const struct task_struct *task)
 
 #define setup_thread_stack(new,old)	do { } while(0)
 
+/*; Iamroot17A 2020.Nov.28 #2.1
+ *;
+ *; (CONFIG_THREAD_INFO_IN_STACK=y인 경우 사용됨)
+ *; 만약 struct thread_info가 struct task_struct의 멤버인 경우
+ *; struct task_struct의 stack을 반환한다. (defconfig에서 y)
+ *; */
 static inline unsigned long *end_of_stack(const struct task_struct *task)
 {
 	return task->stack;
@@ -47,6 +53,11 @@ static inline void setup_thread_stack(struct task_struct *p, struct task_struct 
  * When the stack grows up, this is the highest address.
  * Beyond that position, we corrupt data on the next page.
  */
+/*; Iamroot17A 2020.Nov.28 #2.2
+ *;
+ *; 만약 struct thread_info가 struct task_struct의 멤버가 아닌 경우
+ *; union thread_union을 이용하여 해당 task_struct의 stack 주소를 알아낸다.
+ *; */
 static inline unsigned long *end_of_stack(struct task_struct *p)
 {
 #ifdef CONFIG_STACK_GROWSUP

--- a/init/init_task.c
+++ b/init/init_task.c
@@ -65,6 +65,13 @@ struct task_struct init_task
 #ifdef CONFIG_ARCH_TASK_STRUCT_ON_STACK
 	__init_task_data
 #endif
+	/*; Iamroot17A 2020.Nov.28 #1.3
+	 *;
+	 *; init_task는 무조건 L1 Cache에 맞게 들어가도록 align되어있음.
+	 *; (이전에는 align이 적용되지 않았으나, 32bit 환경에서 MUTEX flag
+	 *;  문제로 강제로 align되도록 설정됨)
+	 *; >> 관련 commit: d0b7213f895cd0e209ff5ba89998aeb09267bdc7
+	 *; */
 	__aligned(L1_CACHE_BYTES)
 = {
 #ifdef CONFIG_THREAD_INFO_IN_TASK

--- a/init/main.c
+++ b/init/main.c
@@ -838,6 +838,13 @@ asmlinkage __visible void __init __no_sanitize_address start_kernel(void)
 	char *command_line;
 	char *after_dashes;
 
+	/*; Iamroot17A 2020.Nov.28 #1
+	 *;
+	 *; set_task_stack_end_magic의 Arg로 전달된 init_task 분석
+	 *; (struct task_struct 및 초기 값 분석)
+	 *;
+	 *; 항목이 너무 많아 초반 부분만 다루고 나중에 필요시 확인하기로 함.
+	 *; */
 	set_task_stack_end_magic(&init_task);
 	smp_setup_processor_id();
 	debug_objects_early_init();

--- a/kernel/fork.c
+++ b/kernel/fork.c
@@ -842,7 +842,16 @@ void set_task_stack_end_magic(struct task_struct *tsk)
 {
 	unsigned long *stackend;
 
+	/*; Iamroot17A 2020.Nov.28 #2
+	 *;
+	 *; Kernel stack의 끝 주소를 알아내기 위한 end_of_stack 분석
+	 *; */
 	stackend = end_of_stack(tsk);
+	/*; Iamroot17A 2020.Nov.28 #3
+	 *;
+	 *; Kernel Stack의 Overflow를 감지하기 위해 마지막 부분에
+	 *; magic number로 변경해놓는다.
+	 *; */
 	*stackend = STACK_END_MAGIC;	/* for overflow detection */
 }
 

--- a/lib/debugobjects.c
+++ b/lib/debugobjects.c
@@ -1271,6 +1271,11 @@ void __init debug_objects_early_init(void)
 {
 	int i;
 
+	/*; Iamroot17A 2020.Nov.28 #6
+	 *;
+	 *; debug시 spin_lock과 hash_list를 사용하는 것으로 보임.
+	 *; 관련 변수 초기화 작업
+	 *; */
 	for (i = 0; i < ODEBUG_HASH_SIZE; i++)
 		raw_spin_lock_init(&obj_hash[i].lock);
 


### PR DESCRIPTION
* 2020년 11월 28일
* 코드 버전: mainline 5.9
* init/main.c start_kernel() 분석 시작
  * init_task 및 struct task_struct 분석
  * set_task_stack_end_magic() 분석
  * smp_setup_processor_id() 분석
    * MPIDR_EL1, MIDR_EL1 분석
  * debug_object_early_init() 분석
  * cgroup_init_early() 분석 중
    * cgrp_dfl_root의 정의 (DEFINE_PER_CPU 분석)
    * init_cgroup_root() 분석
      * list.h의 INIT_LIST_HEAD에서 WRITE_ONCE 사용 이유 분석
      * atomic_set의 architecture dependent 구현 흐름 분석
      * init_cgroup_housekeeping() 분석
        * 커널 내 linked list 사용법에 대한 분석
        * mutex, spin_lock, optimistic_spin_queue 분석
        * prev_cputime 분석
        * for_each_subsys() 매크로 분석
    * RCU_INIT_POINTER() 매크로 분석 중